### PR TITLE
Setup jupyter book

### DIFF
--- a/.github/workflows/build_pages.yml
+++ b/.github/workflows/build_pages.yml
@@ -1,0 +1,75 @@
+name: deploy-book
+
+# Run this when the master or main branch changes
+on:
+  push:
+    branches:
+    - main
+    # If your git repository has the Jupyter Book within some-subfolder next to
+    # unrelated files, you can make this run only if a file within that specific
+    # folder has been modified.
+    #
+    # paths:
+    # - some-subfolder/**
+
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+# Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
+permissions:
+    contents: read
+    pages: write
+    id-token: write
+
+# Allow one concurrent deployment, cancelling any in-progress deployments
+# This is useful if you are making a lot of changes to the book
+# and don't want to wait for the previous deployment to finish
+concurrency:
+    group: "pages"
+    cancel-in-progress: true
+
+# This job installs dependencies, builds the book, and pushes it to `gh-pages`
+jobs:
+  deploy-book:
+    runs-on: ubuntu-latest
+    permissions:
+      pages: write
+      id-token: write
+    steps:
+    - uses: actions/checkout@v4
+
+    # Install dependencies
+    - name: Set up Python 3.11
+      uses: actions/setup-python@v5
+      with:
+        python-version: 3.11
+
+    - name: Install dependencies
+      run: |
+        pip install -r requirements.txt
+
+    # (optional) Cache your executed notebooks between runs
+    # if you have config:
+    # execute:
+    #   execute_notebooks: cache
+    # - name: cache executed notebooks
+    #   uses: actions/cache@v3
+    #   with:
+    #     path: _build/.jupyter_cache
+    #     key: jupyter-book-cache-${{ hashFiles('requirements.txt') }}
+
+    # Build the book
+    - name: Build the book
+      run: |
+        jupyter-book build .
+
+    # Upload the book's HTML as an artifact
+    - name: Upload artifact
+      uses: actions/upload-pages-artifact@v3
+      with:
+        path: "_build/html"
+
+    # Deploy the book's HTML to GitHub Pages
+    - name: Deploy to GitHub Pages
+      id: deployment
+      uses: actions/deploy-pages@v4

--- a/.gitignore
+++ b/.gitignore
@@ -169,3 +169,6 @@ cython_debug/
 
 # PyPI configuration file
 .pypirc
+
+# macOS file
+.DS_Store

--- a/.gitignore
+++ b/.gitignore
@@ -172,3 +172,6 @@ cython_debug/
 
 # macOS file
 .DS_Store
+
+# jupyter-book build output
+_build/

--- a/_config.yml
+++ b/_config.yml
@@ -3,6 +3,7 @@
 
 title: From Samples to Knowledge 2025
 author: Sarah McArdle, Zbigniew Mikulski, Michael Nelson
+copyright: 2025
 # logo: logo.png
 
 # Don't execute the code cells in the book when building it

--- a/_config.yml
+++ b/_config.yml
@@ -6,6 +6,10 @@ author: Sarah McArdle, Zbigniew Mikulski, Michael Nelson
 copyright: 2025
 # logo: logo.png
 
+# Only build files in the table of contents.
+only_build_toc_files: true
+
+
 # Don't execute the code cells in the book when building it
 # See https://jupyterbook.org/content/execute.html
 execute:

--- a/_config.yml
+++ b/_config.yml
@@ -1,0 +1,41 @@
+# Book settings
+# Learn more at https://jupyterbook.org/customize/config.html
+
+title: From Samples to Knowledge 2025
+authors:
+  - name: Sarah McArdle
+    affiliation: LJI
+  - name: Michael Nelson
+    affiliation: LOCI
+# logo: logo.png
+
+# Don't execute the code cells in the book when building it
+# See https://jupyterbook.org/content/execute.html
+execute:
+  execute_notebooks: off
+
+# Define the name of the latex output file for PDF builds
+latex:
+  latex_documents:
+    targetname: book.tex
+
+# Add a bibtex file so that we can create citations
+# bibtex_bibfiles:
+#  - references.bib
+
+# Information about where the book exists on the web
+repository:
+  url: https://github.com/saramcardle/FS2K  # Online location of your book
+  branch: main  # Which branch of the repository should be used when creating links (optional)
+
+# Add GitHub buttons to your book
+# See https://jupyterbook.org/customize/config.html#add-a-link-to-your-repository
+html:
+  use_issues_button: false
+  use_repository_button: true
+  static_path:
+    - Images
+
+parse:
+  myst_enable_extensions:
+    - html_image

--- a/_config.yml
+++ b/_config.yml
@@ -2,11 +2,7 @@
 # Learn more at https://jupyterbook.org/customize/config.html
 
 title: From Samples to Knowledge 2025
-authors:
-  - name: Sarah McArdle
-    affiliation: LJI
-  - name: Michael Nelson
-    affiliation: LOCI
+author: Sarah McArdle, Zbigniew Mikulski, Michael Nelson
 # logo: logo.png
 
 # Don't execute the code cells in the book when building it

--- a/_config.yml
+++ b/_config.yml
@@ -30,8 +30,6 @@ repository:
 html:
   use_issues_button: false
   use_repository_button: true
-  static_path:
-    - Images
 
 parse:
   myst_enable_extensions:

--- a/_toc.yml
+++ b/_toc.yml
@@ -1,0 +1,18 @@
+# Table of contents
+# Learn more at https://jupyterbook.org/customize/toc.html
+
+format: jb-book
+root: README
+chapters:
+- file: Session 1- Visualization.ipynb
+- file: Session 2- Tissue Annotations.ipynb
+- file: Session 3- Pixel Classifier.ipynb
+- file: Session 4- Cell Detection.ipynb
+- file: Session 5 - Workflows to Scripts.ipynb
+- file: Session 6 - Classifying Cells pt1.ipynb
+- file: Session 7 - More Difficult Classifiers.ipynb
+- file: Session 8 - Creating Multiplex Classifiers.ipynb
+- file: Session 9 - Data Export and Simplification.ipynb
+- file: Session 10- Combining Images.ipynb
+- file: Session 11 - Pixel Classifier for non-round cells.ipynb
+- file: Session 12- Spatial Analysis.ipynb

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,1 @@
+jupyter-book


### PR DESCRIPTION
Ok so this PR enables using jupyter-book to build a static website from your notebooks.
Here's the docs:
https://jupyterbook.org/en/stable/intro.html#

I added some comments in the PR and there are links to docs in the two config files (_config and _toc).

The PR includes a GitHub action to build things on CI and deploy to GitHub pages.
You need to go into your repo settings, click Pages on the left and select GitHub Actions:
![image](https://github.com/user-attachments/assets/eb56c55b-3835-4ee8-b4e6-5f91785cbd48)

Also, ensure you have Actions enabled. Click on the Actions tab of the repo and enabled actions.

If you want to build locally, then you need to make a python 3.11 environment and install `jupyter-book`.
Activate the env and then do:
`jupyter-book build .`
This will create a `_build/html` folder with all the html (it's in gitignore so you won't make extra stuff on GitHub)
Then you can serve it using:
`python -m http.server`
And use your browser to go to: `http://localhost:8000/_build/html/README.html`


Once the site is deployed, go to the repo site, top right, About, click the cog and ensure the site is used "Use your GitHub Pages"
Here is this PR merged into my fork, so you can preview it.
https://psobolewskiphd.github.io/FS2K/README.html

Notice some of the image links are broken, e.g. Session 2. It's easy to fix with search and replace, but I **didn't fix** because I didn't want to create massive merge conflicts.
The problem images are where the path was windows `\` instead of `/` -- jupyter should understand both, but the html needs the latter. And where `attachment:` was used.
Those should be
`![ALT TEXT](Images/path_to_image.PNG)`
