### PR TITLE
Add dollarmath flag to _config.yml

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -38,3 +38,4 @@ html:
 parse:
   myst_enable_extensions:
     - html_image
+    - dollarmath


### PR DESCRIPTION
This should fix the equations, it does for me locally:
<img width="879" alt="image" src="https://github.com/user-attachments/assets/fed914fd-d444-4ee5-9919-29586cd4de57" />
Surprised this isn't a default `on` setting.

There are a lot of other config options we can look at:
https://jupyterbook.org/en/stable/customize/config.html