### PR TITLE
Restrict jupyter-book < 2 to fix build

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-jupyter-book
+jupyter-book < 2


### PR DESCRIPTION
Jupyter-book v2 changes things significantly, see:
https://jupyterbook.org/stable/resources/upgrade/

So in lieu of updating, i'm doing the lazy upper bounds.